### PR TITLE
Add Ceramic DID Encryption Scheme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@scure/base": "^1.2.6",
         "dids": "^5.0.3",
         "key-did-provider-ed25519": "^4.0.2",
+        "key-did-resolver": "^4.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2969,6 +2970,21 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/key-did-resolver": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-4.0.0.tgz",
+      "integrity": "sha512-+U2nd/0rjO4Yqe2hnHBD7ygcLRfT43Oje9IIjv1BlBi0lopwxZpIFQ7GekguOHK02r+JGdl8mpJVNHs5lvXVOA==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "@noble/curves": "^1.2.0",
+        "multiformats": "^13.0.0",
+        "uint8arrays": "^5.0.1",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4078,6 +4094,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "license": "MIT"
     },
     "node_modules/viem": {
       "version": "1.21.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@metamask/eth-sig-util": "^8.2.0",
+        "@noble/hashes": "^1.8.0",
         "@scure/base": "^1.2.6",
+        "dids": "^5.0.3",
+        "key-did-provider-ed25519": "^4.0.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -20,6 +23,12 @@
         "vite": "^7.0.3",
         "vite-plugin-node-polyfills": "^0.24.0"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -315,6 +324,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@didtools/cacao": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@didtools/cacao/-/cacao-3.0.1.tgz",
+      "integrity": "sha512-vV1JirxqVsBf2dqdvoS/msNN8fabvMfseZB0kf1FG8TbosrHd81+hgDOlQMZit7zJbTk5g3CGkZg3b7iYKkynw==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "@didtools/codecs": "^3.0.0",
+        "@didtools/siwx": "2.0.0",
+        "@ipld/dag-cbor": "^9.0.7",
+        "caip": "^1.1.0",
+        "multiformats": "^13.0.0",
+        "uint8arrays": "^5.0.1",
+        "viem": "^1.21.4"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@didtools/codecs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@didtools/codecs/-/codecs-3.0.0.tgz",
+      "integrity": "sha512-TemoVySZrs1XflMtOkwVTATtZEs42Mh2yk9SoYvBXES6Mz30PBJCm8v7U/2y1N5lrjb2cAPWs48Ryc7paetSxQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "codeco": "^1.2.0",
+        "multiformats": "^13.0.0",
+        "uint8arrays": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@didtools/pkh-ethereum": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@didtools/pkh-ethereum/-/pkh-ethereum-0.6.0.tgz",
+      "integrity": "sha512-9lYcQmiI+8D5zv438H/6oweMi7UbKk9ch5ZOHkdAuCZYIP/sBP6ItMe/Nim34MZKV4emCuuHeZ1Z0xwXOLXF8A==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "@didtools/cacao": "^3.0.0",
+        "@noble/curves": "^1.2.0",
+        "@noble/hashes": "^1.3.2",
+        "@stablelib/random": "^1.0.2",
+        "caip": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@didtools/siwx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@didtools/siwx/-/siwx-2.0.0.tgz",
+      "integrity": "sha512-eqBtI5dZrptXTCyadnhvU0di/KvumoByT7F8KB/8BLU7M1lltfEmvf/c5AnsyrWO9338ygCs2u5mKz1p1Zdj5A==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "codeco": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -810,6 +879,20 @@
         "node": ">=14"
       }
     },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.4.tgz",
+      "integrity": "sha512-GbDWYl2fdJgkYtIJN0HY9oO0o50d1nB4EQb7uYWKUd2ztxCjxiEW3PjwGG0nqUpN1G4Cug6LX8NzbA7fKT+zfA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
@@ -929,6 +1012,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.4.1.tgz",
+      "integrity": "sha512-QCOA9cgf3Rc33owG0AYBB9wszz+Ul2kramWN8tXG44Gyciud/tbkEqvxRF/IpqQaBpRBNi9f4jdNxqB2CQCIXg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
@@ -1378,6 +1476,37 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/random": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1464,6 +1593,30 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
+      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/asn1.js": {
@@ -1766,6 +1919,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/caip": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/caip/-/caip-1.1.1.tgz",
+      "integrity": "sha512-a3v5lteUUOoyRI0U6qe5ayCCGkF2mCmJ5zQMDnOD2vRjgRg6sm9p8TsRC2h4D4beyqRN9RYniphAPnj/+jQC6g==",
+      "license": "MIT"
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -1837,6 +1996,24 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.12.tgz",
+      "integrity": "sha512-z126yLoavS75cdTuiKu61RC3Y3trqtDAgQRa5Q0dpHn1RmqhIedptWXKnk0lQ5yo/GmcV9myvIkzFgZ8GnqSog==",
+      "license": "Apache-2.0",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
     "node_modules/cipher-base": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
@@ -1850,6 +2027,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/codeco": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/codeco/-/codeco-1.4.3.tgz",
+      "integrity": "sha512-NG2kuhCtCNVKWYEwhVb6yg1QU/hYbMUIsaJkxXGEypHQIBClAvMGQhiheEX6c4C9Dwi9L/UuzeO66Us3KrK1rA==",
+      "license": "(MIT OR Apache-2.0)"
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -1971,6 +2154,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dag-jose-utils": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-4.0.0.tgz",
+      "integrity": "sha512-bmmXtVdEKp/zYH8El4GGkMREJioUztz8fzOErfy5dTbyKIVOF61C5sfsZLYCB/wiT/I9+SPNrQeo/Cx6Ik3wJQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.7",
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2033,6 +2226,66 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/did-jwt": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-7.4.7.tgz",
+      "integrity": "sha512-Apz7nIfIHSKWIMaEP5L/K8xkwByvjezjTG0xiqwKdnNj1x8M0+Yasury5Dm/KPltxi2PlGfRPf3IejRKZrT8mQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ciphers": "^0.4.0",
+        "@noble/curves": "^1.0.0",
+        "@noble/hashes": "^1.3.0",
+        "@scure/base": "^1.1.3",
+        "canonicalize": "^2.0.0",
+        "did-resolver": "^4.1.0",
+        "multibase": "^4.0.6",
+        "multiformats": "^9.6.2",
+        "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/did-jwt/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/did-jwt/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/did-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.1.0.tgz",
+      "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dids": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/dids/-/dids-5.0.3.tgz",
+      "integrity": "sha512-VAgMnoD/DA8hZBZ9Km3M45jaeD3uRVo+GLT8dg8+SPECDPCzCqX/0eVSAHgEnppbP6+p297H2d826cS2Qmd6wg==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "@didtools/cacao": "^3.0.1",
+        "@didtools/codecs": "^3.0.0",
+        "@didtools/pkh-ethereum": "^0.6.0",
+        "@stablelib/random": "^1.0.2",
+        "codeco": "^1.2.0",
+        "dag-jose-utils": "^4.0.0",
+        "did-jwt": "^7.4.7",
+        "did-resolver": "^4.1.0",
+        "multiformats": "^13.0.0",
+        "rpc-utils": "^0.6.2",
+        "uint8arrays": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/diffie-hellman": {
@@ -2248,6 +2501,12 @@
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.4.6",
@@ -2645,6 +2904,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/isows": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
+      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2676,6 +2950,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/key-did-provider-ed25519": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-4.0.2.tgz",
+      "integrity": "sha512-bnnRGuuUtylKGMVmgXVSoGccBg87roFi6xy5dQmTgNqnCmrxBBUatYoVimcnA+SGCFqi2qk6B9dD10Ed4rTZPg==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "did-jwt": "^7.4.7",
+        "dids": "^5.0.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "rpc-utils": "^0.6.2",
+        "uint8arrays": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/locate-path": {
@@ -2789,11 +3080,30 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multibase": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
+      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
+      "dependencies": {
+        "@multiformats/base-x": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/multiformats": {
+      "version": "13.3.7",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.7.tgz",
+      "integrity": "sha512-meL9DERHj+fFVWoOX9fXqfcYcSpUfSYJPcFvDPKrxitICbwAoWR+Ut4j5NO9zAT917HUHLQmqzQbAsGNHlDcxQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3362,6 +3672,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rpc-utils": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rpc-utils/-/rpc-utils-0.6.2.tgz",
+      "integrity": "sha512-kzk1OflbBckfDBAo8JwsmtQSHzj+6hxRt5G+u8A8ZSmunBw1nhWvRkSq8j1+EvWBqBRLy1aiGLUW5644CZqQtA==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3669,6 +3991,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -3746,6 +4077,96 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/viem": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-1.21.4.tgz",
+      "integrity": "sha512-BNVYdSaUjeS2zKQgPs+49e5JKocfo60Ib2yiXOWBT6LuVxY1I/6fFX3waEtpXvL1Xn4qu+BVitVtMh9lyThyhQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@scure/bip32": "1.3.2",
+        "@scure/bip39": "1.2.1",
+        "abitype": "0.9.8",
+        "isows": "1.0.3",
+        "ws": "8.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/bip32": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.2.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/vite": {
@@ -3867,6 +4288,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   },
   "dependencies": {
     "@metamask/eth-sig-util": "^8.2.0",
+    "@noble/hashes": "^1.8.0",
     "@scure/base": "^1.2.6",
+    "dids": "^5.0.3",
+    "key-did-provider-ed25519": "^4.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@scure/base": "^1.2.6",
     "dids": "^5.0.3",
     "key-did-provider-ed25519": "^4.0.2",
+    "key-did-resolver": "^4.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/components/CeramicDid.jsx
+++ b/src/components/CeramicDid.jsx
@@ -1,3 +1,58 @@
-export function CeramicDid({ message }) {
-  return <p>MESSAGE: {btoa(message)}</p>;
+import { sha256 } from "@noble/hashes/sha2.js";
+import { base16, base64 } from "@scure/base";
+import { DID } from "dids";
+import { Ed25519Provider } from "key-did-provider-ed25519";
+import KeyResolver from "key-did-resolver";
+import { EncryptionScheme, atou, utoa } from "./EncryptionScheme.jsx";
+
+async function createDid(wallet) {
+  const entropy = await wallet.provider.request({
+    method: "personal_sign",
+    params: [
+      `authorize access to your encrypted data on ${window.location.href}`,
+      wallet.address,
+    ],
+  });
+  const seed = sha256(base16.decode(entropy.replace(/^0x/, "").toUpperCase()));
+  const did = new DID({
+    resolver: KeyResolver.getResolver(),
+    provider: new Ed25519Provider(seed),
+  });
+  await did.authenticate();
+  return did;
+}
+
+async function generateKey(wallet) {
+  const did = await createDid(wallet);
+  return did.id;
+}
+
+async function encrypt(publicKey, data) {
+  const did = new DID({
+    resolver: KeyResolver.getResolver(),
+  });
+  const bytes = atou(data);
+  const jwe = await did.createJWE(bytes, [publicKey]);
+  const encoded = base64.encode(atou(JSON.stringify(jwe)));
+  return encoded;
+}
+
+async function decrypt(wallet, data) {
+  const decoded = utoa(base64.decode(data.trim()));
+  const jwe = JSON.parse(decoded);
+  const did = await createDid(wallet);
+  const bytes = await did.decryptJWE(jwe);
+  const message = utoa(bytes);
+  return message;
+}
+
+export function CeramicDid(props) {
+  return (
+    <EncryptionScheme
+      generateKey={generateKey}
+      encrypt={encrypt}
+      decrypt={decrypt}
+      {...props}
+    />
+  );
 }

--- a/src/components/EncryptionScheme.jsx
+++ b/src/components/EncryptionScheme.jsx
@@ -31,7 +31,7 @@ export function EncryptionScheme({
   }, [generateKey, wallet, setEncryptionKey, startTransition]);
 
   const handleEncrypt = useCallback(() => {
-    startTransition(async () => {
+    startEncryption(async () => {
       const encrypted = await encrypt(encryptionKey, plaintext);
       setCiphertext(encrypted);
     });

--- a/src/components/EncryptionScheme.jsx
+++ b/src/components/EncryptionScheme.jsx
@@ -1,5 +1,13 @@
 import { useCallback, useState, useTransition } from "react";
 
+export function atou(s) {
+  return new TextEncoder().encode(s);
+}
+
+export function utoa(u) {
+  return new TextDecoder().decode(u);
+}
+
 export function EncryptionScheme({
   generateKey,
   encrypt,

--- a/src/components/EncryptionScheme.jsx
+++ b/src/components/EncryptionScheme.jsx
@@ -1,0 +1,86 @@
+import { useCallback, useState, useTransition } from "react";
+
+export function EncryptionScheme({
+  generateKey,
+  encrypt,
+  decrypt,
+  wallet,
+  plaintext,
+  setPlaintext,
+  ciphertext,
+  setCiphertext,
+}) {
+  const [encryptionKey, setEncryptionKey] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const [isEncrypting, startEncryption] = useTransition();
+  const [isDecrypting, startDecryption] = useTransition();
+
+  const handleRequestEncryptionKey = useCallback(() => {
+    startTransition(async () => {
+      const key = await generateKey(wallet);
+      setEncryptionKey(key);
+    });
+  }, [generateKey, wallet, setEncryptionKey, startTransition]);
+
+  const handleEncrypt = useCallback(() => {
+    startTransition(async () => {
+      const encrypted = await encrypt(encryptionKey, plaintext);
+      setCiphertext(encrypted);
+    });
+  }, [encrypt, encryptionKey, plaintext, setCiphertext, startEncryption]);
+
+  const handleDecrypt = useCallback(() => {
+    startDecryption(async () => {
+      const decrypted = await decrypt(wallet, ciphertext);
+      setPlaintext(decrypted);
+    });
+  }, [decrypt, wallet, ciphertext, setPlaintext, startDecryption]);
+
+  return (
+    <>
+      <p>
+        Encryption key:{" "}
+        <input
+          value={encryptionKey}
+          onChange={(e) => setEncryptionKey(e.target.value)}
+          style={{
+            fontFamily: "monospace",
+            textOverflow: "ellipsis",
+            width: "400px",
+          }}
+        />
+        <button
+          onClick={handleRequestEncryptionKey}
+          disabled={isPending}
+          style={{
+            cursor: "pointer",
+            marginLeft: "8px",
+          }}
+        >
+          {isPending ? "Requesting..." : "Request"}
+        </button>
+      </p>
+      <div>
+        <button
+          onClick={handleEncrypt}
+          disabled={isEncrypting || !encryptionKey}
+          style={{
+            cursor: "pointer",
+          }}
+        >
+          {isEncrypting ? "Encrypting..." : "Encrypt"}
+        </button>
+        <button
+          onClick={handleDecrypt}
+          disabled={isDecrypting || !ciphertext}
+          style={{
+            cursor: "pointer",
+            marginLeft: "8px",
+          }}
+        >
+          {isDecrypting ? "Decrypting..." : "Decrypt"}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/MetaMaskSnap.jsx
+++ b/src/components/MetaMaskSnap.jsx
@@ -1,14 +1,6 @@
 import { encrypt } from "@metamask/eth-sig-util";
 import { base16, base64 } from "@scure/base";
-import { EncryptionScheme } from "./EncryptionScheme.jsx";
-
-function atou(s) {
-  return new TextEncoder().encode(s);
-}
-
-function utoa(u) {
-  return new TextDecoder().decode(u);
-}
+import { EncryptionScheme, atou, utoa } from "./EncryptionScheme.jsx";
 
 async function generateKey(wallet) {
   await wallet.provider.request({
@@ -34,32 +26,32 @@ async function generateKey(wallet) {
 }
 
 function doEncrypt(publicKey, data) {
-    const encrypted = encrypt({
-      publicKey,
-      data,
-      version: "x25519-xsalsa20-poly1305",
-    });
+  const encrypted = encrypt({
+    publicKey,
+    data,
+    version: "x25519-xsalsa20-poly1305",
+  });
   const encoded = base64.encode(atou(JSON.stringify(encrypted)));
   // The API expects a promise, even if we don't need `encrypt` to be async.
   return Promise.resolve(encoded);
 }
 
 async function decrypt(wallet, data) {
-      const decoded = utoa(base64.decode(data.trim()));
-      const encrypted = JSON.parse(decoded);
-      const decrypted = await wallet.provider.request({
-        method: "wallet_snap",
+  const decoded = utoa(base64.decode(data.trim()));
+  const encrypted = JSON.parse(decoded);
+  const decrypted = await wallet.provider.request({
+    method: "wallet_snap",
+    params: {
+      snapId: "npm:@metamask/message-signing-snap",
+      request: {
+        method: "decryptMessage",
         params: {
-          snapId: "npm:@metamask/message-signing-snap",
-          request: {
-            method: "decryptMessage",
-            params: {
-              data: encrypted,
-            },
-          },
+          data: encrypted,
         },
-      });
-      return decrypted;
+      },
+    },
+  });
+  return decrypted;
 }
 
 export function MetaMaskSnap(props) {


### PR DESCRIPTION
This PR adds the Ceramic DID encryption scheme, using a `personal_sign` signature as entropy for the actual secret key. The encryption logic was taken mostly from [a published tutorial](https://blog.ceramic.network/tutorial-encrypted-data-on-composedb/) by Ceramic network. There is [a more recent tutorial](https://developers.ceramic.network/docs/dids/guides/using-with-composedb-client) with specialized Ethereum code (over `@didtools/pkh-ethereum`, although it seems coupled to ComposeDB), but this is in spirit doing the same thing (although, they use sign-in with Ethereum for the entropy and also track session expiry over that). In principle, how it works is:

1. You ask the connected Ethereum wallet to generate a signature
2. You use that signature as entropy for deriving a Ed25519 key-pair
3. You publish the DID for the genrated Ed25519 the public key
4. You encrypt some data using the public key encoded in the DID
5. You decrypt using the generated Ed25519 private key

Note that this implementation makes no effort to cache DID sessions - so a signature is required for every attempt to decrypt some data.

A nice property of Ceramic is that they use actual standards for their packages:

- [DID](https://www.w3.org/TR/did-1.0/): Decentralized Identifiers
- [JWE](https://datatracker.ietf.org/doc/html/rfc7518): JSON Web Encryption (which supports encryption envelopes - i.e. you can generate one JWE blob for multiple DIDs)
  - The MetaMask encryption scheme could be made to support the exact same schemes with some glue code).

---

I also refactored the existing encyrption scheme into a shared component - this allows us to define encryption schemes based on 3 functions:

- Generated an encryption public key (the MetaMask snap public key, or the Ceramic DID ID)
- Encrypting some plaintext data for a public encryption key
- Decrypting some cyphertext with the an encryption private key, derived from the connected wallet

---

<img width="927" height="962" alt="Screenshot From 2025-07-14 12-25-29" src="https://github.com/user-attachments/assets/2b05077b-4d41-49b2-98eb-e45ca2f95c2e" />
