### PR TITLE
Do Not Require Wallet Connection

### DIFF
--- a/src/components/EncryptedMessage.jsx
+++ b/src/components/EncryptedMessage.jsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 
 import { CeramicDid } from "./CeramicDid.jsx";
 import { MetaMaskSnap } from "./MetaMaskSnap.jsx";
-import { useWallet } from "./WalletConnection.jsx";
 
 function Section({ title, children }) {
   return (
@@ -16,12 +15,11 @@ function Section({ title, children }) {
 }
 
 export function EncryptedMessage() {
-  const wallet = useWallet();
   const [plaintext, setPlaintext] = useState("");
   const [ciphertext, setCiphertext] = useState("");
 
-  let props = { wallet, plaintext, setPlaintext, ciphertext, setCiphertext };
-  return wallet ? (
+  let props = { plaintext, setPlaintext, ciphertext, setCiphertext };
+  return (
     <div>
       <h3>Plaintext Message</h3>
       <textarea
@@ -53,7 +51,5 @@ export function EncryptedMessage() {
         <CeramicDid {...props} />
       </Section>
     </div>
-  ) : (
-    <></>
   );
 }

--- a/src/components/EncryptionScheme.jsx
+++ b/src/components/EncryptionScheme.jsx
@@ -46,6 +46,7 @@ export function EncryptionScheme({
     });
   }, [decrypt, wallet, ciphertext, setPlaintext, startDecryption]);
 
+  const missingWallet = !wallet && walletRequired;
   return (
     <>
       <p>
@@ -61,7 +62,7 @@ export function EncryptionScheme({
         />
         <button
           onClick={handleRequestEncryptionKey}
-          disabled={isRequestingKey || (!wallet && walletRequired)}
+          disabled={missingWallet || isRequestingKey}
           style={{
             cursor: "pointer",
             marginLeft: "8px",
@@ -82,7 +83,7 @@ export function EncryptionScheme({
         </button>
         <button
           onClick={handleDecrypt}
-          disabled={isDecrypting || !wallet || !ciphertext}
+          disabled={missingWallet || isDecrypting || !ciphertext}
           style={{
             cursor: "pointer",
             marginLeft: "8px",


### PR DESCRIPTION
Some operations, (like encrypting, and in the future Passkey based schemes) do not require a connected wallet. This PR changes the interface to always load the schemes and just disable the UI components depending on whether or not a wallet is required.