### PR TITLE
Add Passkey Encryption Scheme

### DIFF
--- a/src/components/EncryptedMessage.jsx
+++ b/src/components/EncryptedMessage.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { CeramicDid } from "./CeramicDid.jsx";
 import { MetaMaskSnap } from "./MetaMaskSnap.jsx";
+import { PasskeyPrf } from "./PasskeyPrf.jsx";
 
 function Section({ title, children }) {
   return (
@@ -49,6 +50,10 @@ export function EncryptedMessage() {
 
       <Section title="Ceramic DID Encryption">
         <CeramicDid {...props} />
+      </Section>
+
+      <Section title="Passkey PRF Encryption">
+        <PasskeyPrf {...props} />
       </Section>
     </div>
   );

--- a/src/components/PasskeyPrf.jsx
+++ b/src/components/PasskeyPrf.jsx
@@ -1,0 +1,118 @@
+import { base64 } from "@scure/base";
+import { DID } from "dids";
+import { Ed25519Provider } from "key-did-provider-ed25519";
+import KeyResolver from "key-did-resolver";
+import { EncryptionScheme, atou, utoa } from "./EncryptionScheme.jsx";
+
+async function createCredential() {
+  const credential = await navigator.credentials.create({
+    publicKey: {
+      challenge: Uint8Array.from([0x5a, 0xfe]),
+      rp: {
+        name: "Web3 Encryption Experiments",
+        id: window.location.hostname,
+      },
+      user: {
+        id: Uint8Array.from([0x5a, 0xfe]),
+        name: "research@safe.dev",
+        displayName: "Researcher",
+      },
+      pubKeyCredParams: [
+        { alg: -7, type: "public-key" }, // ES256
+      ],
+      timeout: 60000,
+      attestation: "none",
+      extensions: {
+        prf: {},
+      },
+    },
+  });
+  if (!credential?.prf?.enabled) {
+    // On macOS Safari, the extension is not reported as enabled, even if it
+    // does reply with PRF entropy when attesting.
+    console.warn("PRF extension may not supported by the authenticator");
+  }
+}
+
+async function getCredential() {
+  const credential = await navigator.credentials.get({
+    publicKey: {
+      challenge: Uint8Array.from([0x5a, 0xfe]),
+      userVerification: "discouraged",
+      timeout: 60000,
+      extensions: {
+        prf: {
+          eval: {
+            first: Uint8Array.from([0x5a, 0xfe]),
+          },
+        },
+      },
+    },
+  });
+  return credential;
+}
+
+async function getPrf() {
+  let credential;
+  try {
+    credential = await getCredential();
+  } catch (err) {
+    console.warn(err);
+    await createCredential();
+    credential = await getCredential();
+  }
+
+  const extensions = credential.getClientExtensionResults();
+  const prf = extensions?.prf?.results?.first;
+  if (!prf) {
+    throw new Error("PRF extension not supported by the authenticator");
+  }
+
+  return new Uint8Array(prf);
+}
+
+async function createDid(_wallet) {
+  const seed = await getPrf();
+  const did = new DID({
+    resolver: KeyResolver.getResolver(),
+    provider: new Ed25519Provider(seed),
+  });
+  await did.authenticate();
+  return did;
+}
+
+async function generateKey() {
+  const did = await createDid();
+  return did.id;
+}
+
+async function encrypt(publicKey, data) {
+  const did = new DID({
+    resolver: KeyResolver.getResolver(),
+  });
+  const bytes = atou(data);
+  const jwe = await did.createJWE(bytes, [publicKey]);
+  const encoded = base64.encode(atou(JSON.stringify(jwe)));
+  return encoded;
+}
+
+async function decrypt(_wallet, data) {
+  const decoded = utoa(base64.decode(data.trim()));
+  const jwe = JSON.parse(decoded);
+  const did = await createDid();
+  const bytes = await did.decryptJWE(jwe);
+  const message = utoa(bytes);
+  return message;
+}
+
+export function PasskeyPrf(props) {
+  return (
+    <EncryptionScheme
+      generateKey={generateKey}
+      encrypt={encrypt}
+      decrypt={decrypt}
+      walletRequired={false}
+      {...props}
+    />
+  );
+}

--- a/src/components/PasskeyPrf.jsx
+++ b/src/components/PasskeyPrf.jsx
@@ -54,10 +54,14 @@ async function getCredential() {
 
 async function getPrf() {
   let credential;
+
+  // Try and get any existing credential, and then fall back to creating one if
+  // that fails. This lets us "discover" passkey credentials without having to
+  // actually store any identifiers in local storage for example. There may be
+  // better ways of doing this, but it is good enough for now :).
   try {
     credential = await getCredential();
-  } catch (err) {
-    console.warn(err);
+  } catch {
     await createCredential();
     credential = await getCredential();
   }

--- a/src/components/PasskeyPrf.jsx
+++ b/src/components/PasskeyPrf.jsx
@@ -53,6 +53,11 @@ async function getCredential() {
 }
 
 async function getPrf() {
+  // Check WebAuthn support first
+  if (!window.PublicKeyCredential) {
+    throw new Error("WebAuthn is not supported in this browser");
+  }
+
   let credential;
 
   // Try and get any existing credential, and then fall back to creating one if


### PR DESCRIPTION
This PR adds a new encruption scheme that uses the Passkey PRF extension to generate some deterministic entropy that we use as a seed for an encryption key pair.

This is very similar to the Ceramic DID scheme, but a slight improvement as it:
- Uses a method that is **dedicated** for generating strong cryptographic entropy, and is even designed to be used to generate encryption keys (albeit symetric keys)
- Is not susceptible to phishing, as WebAuthn does not allow credentials to be shared across relaying parties (i.e. Dapps in our case).

It still suffers from the same major downside though, that we are materializing an encryption key in memory, so leaking it is really bad (compared to MetaMask snap scheme, where you don't materialize the decryption key stays in the wallet, meaning that you can at most compromise the decrypted messages, and you maintain forwards and backwards secrecy).